### PR TITLE
File server can throw unhandled exceptions if content changes 

### DIFF
--- a/Criollo/Source/CRConnection.m
+++ b/Criollo/Source/CRConnection.m
@@ -197,10 +197,10 @@ static const NSData * CRLFCRLFData;
         return;
     }
     
-    CRRequest* firstRequest;
-    @synchronized (self) {
+    __block CRRequest* firstRequest;
+    dispatch_sync(self.isolationQueue, ^{
         firstRequest = self.requests.firstObject;
-    }
+    });
     if ( firstRequest == nil || [firstRequest isEqual:request] ) {
         request.bufferedResponseData = nil;
         [self.socket writeData:data withTimeout:self.server.configuration.CRConnectionWriteTimeout tag:CRConnectionSocketTagSendingResponse];
@@ -220,11 +220,7 @@ static const NSData * CRLFCRLFData;
     CRConnection * __weak connection = self;
     [self.delegate connection:self didFinishRequest:request response:request.response];
     dispatch_async(self.isolationQueue, ^{
-        if (connection != nil) {
-            @synchronized (connection) {
-                [connection.requests removeObject:request];
-            }
-        }
+        [connection.requests removeObject:request];
     });
 }
 

--- a/Criollo/Source/CRConnection.m
+++ b/Criollo/Source/CRConnection.m
@@ -197,7 +197,10 @@ static const NSData * CRLFCRLFData;
         return;
     }
     
-    CRRequest* firstRequest = self.requests.firstObject;
+    CRRequest* firstRequest;
+    @synchronized (self) {
+        firstRequest = self.requests.firstObject;
+    }
     if ( firstRequest == nil || [firstRequest isEqual:request] ) {
         request.bufferedResponseData = nil;
         [self.socket writeData:data withTimeout:self.server.configuration.CRConnectionWriteTimeout tag:CRConnectionSocketTagSendingResponse];
@@ -217,7 +220,11 @@ static const NSData * CRLFCRLFData;
     CRConnection * __weak connection = self;
     [self.delegate connection:self didFinishRequest:request response:request.response];
     dispatch_async(self.isolationQueue, ^{
-        [connection.requests removeObject:request];
+        if (connection != nil) {
+            @synchronized (connection) {
+                [connection.requests removeObject:request];
+            }
+        }
     });
 }
 

--- a/Criollo/Source/FCGI/CRFCGIResponse.m
+++ b/Criollo/Source/FCGI/CRFCGIResponse.m
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_END
 - (void)writeData:(NSData *)data finish:(BOOL)flag {
 
     if ( self.finished ) {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Response is already finished" userInfo:nil];
+        return;
     }
 
     NSMutableData* dataToSend = [self initialResponseData];

--- a/Criollo/Source/HTTP/CRHTTPResponse.m
+++ b/Criollo/Source/HTTP/CRHTTPResponse.m
@@ -62,7 +62,7 @@
 
 - (void)writeData:(NSData *)data finish:(BOOL)flag {
     if ( self.finished ) {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Response is already finished" userInfo:nil];
+        return;
     }
 
     NSMutableData* dataToSend = [self initialResponseData];


### PR DESCRIPTION
I'm not sure if dealing with files that wink in and out of existence is in the scope of the Criollo file server, but that's how I'm using it, and I offer the following tweaks to fix the two exceptions mentioned in issue #35.

