### PR TITLE
Handle HTTP/1.0 Headers (With no Host)

### DIFF
--- a/Criollo.xcodeproj/project.pbxproj
+++ b/Criollo.xcodeproj/project.pbxproj
@@ -417,7 +417,7 @@
 		AD61E9741BDD7FDF00F5BD17 /* CRHTTPServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRHTTPServer.h; sourceTree = "<group>"; };
 		AD61E9751BDD7FDF00F5BD17 /* CRHTTPServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRHTTPServer.m; sourceTree = "<group>"; };
 		AD61E9781BDD80C100F5BD17 /* CRHTTPConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRHTTPConnection.h; sourceTree = "<group>"; };
-		AD61E9791BDD80C100F5BD17 /* CRHTTPConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = CRHTTPConnection.m; sourceTree = "<group>"; };
+		AD61E9791BDD80C100F5BD17 /* CRHTTPConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRHTTPConnection.m; sourceTree = "<group>"; };
 		AD61E97D1BDD880C00F5BD17 /* CRFCGIConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRFCGIConnection.h; sourceTree = "<group>"; };
 		AD61E97E1BDD880C00F5BD17 /* CRFCGIConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRFCGIConnection.m; sourceTree = "<group>"; };
 		AD61E97F1BDD880C00F5BD17 /* CRFCGIServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRFCGIServer.h; sourceTree = "<group>"; };

--- a/Criollo.xcodeproj/project.pbxproj
+++ b/Criollo.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		ADEDB3A61AEFCC6400A26AF1 /* NSDate+RFC1123.m in Sources */ = {isa = PBXBuildFile; fileRef = ADEDB3601AEFBD8800A26AF1 /* NSDate+RFC1123.m */; };
 		ADEDB3A71AEFCC8B00A26AF1 /* CRApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = ADEDB34E1AEFBD8800A26AF1 /* CRApplication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ADEDB3AA1AEFCC8B00A26AF1 /* NSDate+RFC1123.h in Headers */ = {isa = PBXBuildFile; fileRef = ADEDB35F1AEFBD8800A26AF1 /* NSDate+RFC1123.h */; };
+		F306C201226A24FF00846DC5 /* CRHTTPConnectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F306C200226A24FF00846DC5 /* CRHTTPConnectionTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -416,7 +417,7 @@
 		AD61E9741BDD7FDF00F5BD17 /* CRHTTPServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRHTTPServer.h; sourceTree = "<group>"; };
 		AD61E9751BDD7FDF00F5BD17 /* CRHTTPServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRHTTPServer.m; sourceTree = "<group>"; };
 		AD61E9781BDD80C100F5BD17 /* CRHTTPConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRHTTPConnection.h; sourceTree = "<group>"; };
-		AD61E9791BDD80C100F5BD17 /* CRHTTPConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRHTTPConnection.m; sourceTree = "<group>"; };
+		AD61E9791BDD80C100F5BD17 /* CRHTTPConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = CRHTTPConnection.m; sourceTree = "<group>"; };
 		AD61E97D1BDD880C00F5BD17 /* CRFCGIConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRFCGIConnection.h; sourceTree = "<group>"; };
 		AD61E97E1BDD880C00F5BD17 /* CRFCGIConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRFCGIConnection.m; sourceTree = "<group>"; };
 		AD61E97F1BDD880C00F5BD17 /* CRFCGIServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRFCGIServer.h; sourceTree = "<group>"; };
@@ -477,6 +478,7 @@
 		ADEDB3761AEFC0B000A26AF1 /* Criollo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Criollo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ADEDB37A1AEFC0B000A26AF1 /* Criollo-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Criollo-Info.plist"; sourceTree = "<group>"; };
 		ADEDB37B1AEFC0B000A26AF1 /* Criollo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Criollo.h; path = ../Criollo.h; sourceTree = "<group>"; };
+		F306C200226A24FF00846DC5 /* CRHTTPConnectionTests.m */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = CRHTTPConnectionTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -595,6 +597,7 @@
 		AD030FDC1F0C02C900BD9FE4 /* CriolloTests */ = {
 			isa = PBXGroup;
 			children = (
+				F306C200226A24FF00846DC5 /* CRHTTPConnectionTests.m */,
 				4A84C76E1F97E6FE001CC0A5 /* CRHTTPServerTests.m */,
 				4AD0AD581F6662AA00943DC3 /* CRHTTPSHelperTests.m */,
 				AD7F2F701F1A1D6D001DD6BE /* CRMimeTypeHelperTests.m */,
@@ -1142,6 +1145,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = ADEDB3471AEFBCF700A26AF1;
@@ -1342,6 +1346,7 @@
 				4AD0AD591F6662AA00943DC3 /* CRHTTPSHelperTests.m in Sources */,
 				AD1D44F81F376DED00C5D260 /* CRViewTests.m in Sources */,
 				AD1D44E21F375DE100C5D260 /* CRNibTests.m in Sources */,
+				F306C201226A24FF00846DC5 /* CRHTTPConnectionTests.m in Sources */,
 				4A689EE1222FD4C70074DEA3 /* CRRouterTests.m in Sources */,
 				4A84C76F1F97E6FE001CC0A5 /* CRHTTPServerTests.m in Sources */,
 				AD7F2F711F1A1D6D001DD6BE /* CRMimeTypeHelperTests.m in Sources */,

--- a/Criollo/Source/HTTP/CRHTTPConnection.m
+++ b/Criollo/Source/HTTP/CRHTTPConnection.m
@@ -140,14 +140,17 @@
                     NSRange rangeOfHostHeader = [data rangeOfData:[@"Host: " dataUsingEncoding:NSUTF8StringEncoding] options:0 range:NSMakeRange(0, data.length)];
 
                     if ( rangeOfHostHeader.location != NSNotFound || version == CRHTTPVersion1_0 ) {
-                        NSRange rangeOfNewLineAfterHost = [data rangeOfData:[CRConnection CRLFData] options:0 range:NSMakeRange(rangeOfHostHeader.location + rangeOfHostHeader.length, data.length - rangeOfHostHeader.location - rangeOfHostHeader.length)];
-
-                        if ( rangeOfNewLineAfterHost.location == NSNotFound ) {
-                            rangeOfNewLineAfterHost.location = data.length - 1;
+                        NSString* hostSpec = @"www.example.com";
+                        if (rangeOfHostHeader.location != NSNotFound) {
+                            NSRange rangeOfNewLineAfterHost = [data rangeOfData:[CRConnection CRLFData] options:0 range:NSMakeRange(rangeOfHostHeader.location + rangeOfHostHeader.length, data.length - rangeOfHostHeader.location - rangeOfHostHeader.length)];
+                            
+                            if ( rangeOfNewLineAfterHost.location == NSNotFound ) {
+                                rangeOfNewLineAfterHost.location = data.length - 1;
+                            }
+                            
+                            NSRange hostSpecRange = NSMakeRange(rangeOfHostHeader.location + rangeOfHostHeader.length, rangeOfNewLineAfterHost.location - rangeOfHostHeader.location - rangeOfHostHeader.length);
+                            hostSpec = [[NSString alloc] initWithBytesNoCopy:(void *)data.bytes + hostSpecRange.location length:hostSpecRange.length encoding:NSUTF8StringEncoding freeWhenDone:NO];
                         }
-
-                        NSRange hostSpecRange = NSMakeRange(rangeOfHostHeader.location + rangeOfHostHeader.length, rangeOfNewLineAfterHost.location - rangeOfHostHeader.location - rangeOfHostHeader.length);
-                        NSString* hostSpec = [[NSString alloc] initWithBytesNoCopy:(void *)data.bytes + hostSpecRange.location length:hostSpecRange.length encoding:NSUTF8StringEncoding freeWhenDone:NO];
 
                         // TODO: request.URL should be parsed using no memcpy and using the actual scheme
                         NSURL* URL = [NSURL URLWithString:[NSString stringWithFormat:@"http%@://%@%@", ((CRHTTPServer *)self.server).isSecure ? @"s" : @"", hostSpec, pathSpec]];

--- a/CriolloTests/CRHTTPConnectionTests.m
+++ b/CriolloTests/CRHTTPConnectionTests.m
@@ -1,0 +1,83 @@
+//
+//  CRHTTPConnectionTests.m
+//  CriolloTests macOS
+//
+//  Created by Adam Fedor on 4/19/19.
+//  Copyright © 2019 Cătălin Stan. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "CRHTTPConnection.h"
+#import "CRConnection_Internal.h"
+#import "CRRequest.h"
+#import "GCDAsyncSocket.h"
+
+#define http11Header @"GET /myendpoint HTTP/1.1\r\n\
+Host: www.criollo.com\r\n\
+Connection: keep-alive\r\n\
+Cache-Control: max-age=0\r\n\
+Upgrade-Insecure-Requests: 1\r\n\
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36\r\n\
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n\
+Accept-Encoding: gzip, deflate\r\n\
+Accept-Language: en-US,en;q=0.9\r\n"
+
+#define http10Header @"GET /myendpoint HTTP/1.0\r\n\
+Connection: keep-alive\r\n\
+Cache-Control: max-age=0\r\n\
+Upgrade-Insecure-Requests: 1\r\n\
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36\r\n\
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n\
+Accept-Encoding: gzip, deflate\r\n\
+Accept-Language: en-US,en;q=0.9\r\n"
+
+@interface CRHTTPConnection (PrivateTesting) <GCDAsyncSocketDelegate>
+@end
+
+@interface CRHTTPConnectionTests : XCTestCase
+
+@end
+
+@implementation CRHTTPConnectionTests
+{
+    CRHTTPConnection *sut;
+}
+
+- (void)setUp {
+    sut = [[CRHTTPConnection alloc] init];
+}
+
+- (void)tearDown {
+    sut = nil;
+}
+
+- (NSData *) dataFromHeaderString:(NSString *)string
+{
+    return [string dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+- (void)testSocketDidReadData_WithHTTPVersion10_ShouldNotThrow {
+    NSData *data = [self dataFromHeaderString:http10Header];
+    
+    XCTAssertNoThrow([sut socket:(GCDAsyncSocket * _Nonnull)nil didReadData:data withTag:CRHTTPConnectionSocketTagBeginReadingRequest]);
+}
+
+- (void)testSocketDidReadData_WithHTTPVersion10_ShouldCreateRequest {
+    NSData *data = [self dataFromHeaderString:http10Header];
+    
+    [sut socket:(GCDAsyncSocket * _Nonnull)nil didReadData:data withTag:CRHTTPConnectionSocketTagBeginReadingRequest];
+    
+    XCTAssertNotNil(sut.currentRequest, "Nil HTTP Version 1.0 request");
+}
+
+- (void)testSocketDidReadData_WithHTTPVersion11_ShouldCreateRequest {
+    NSData *data = [self dataFromHeaderString:http11Header];
+    
+    [sut socket:(GCDAsyncSocket * _Nonnull)nil didReadData:data withTag:CRHTTPConnectionSocketTagBeginReadingRequest];
+    
+    XCTAssertNotNil(sut.currentRequest, "Nil HTTP Version 1.1 request");
+    XCTAssertEqualObjects(sut.currentRequest.URL.host, @"www.criollo.com", @"Incorrect host for HTTP 1.1 request");
+}
+
+
+@end


### PR DESCRIPTION
HTTP Version 1.0 headers don't have to have a Host: field, which causes a crash in CGHTTPConnection trying to find the range of "Host:"