### PR TITLE
Adds block for patch method

### DIFF
--- a/Criollo/Source/Routing/CRRouter.h
+++ b/Criollo/Source/Routing/CRRouter.h
@@ -137,6 +137,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)put:(NSString * _Nullable)path block:(CRRouteBlock)block;
 
+
+/**
+ Adds a block to a pathspec, for the PATCH method, non-recursively.
+
+ @param path  The path specification.
+ @param block The `CRRouteBlock` to be executed.
+ */
+- (void)patch:(NSString *)path block:(CRRouteBlock)block;
+  
 /**
  Adds a block to a pathspec, for the DELETE method, non-recursively.
 

--- a/Criollo/Source/Routing/CRRouter.m
+++ b/Criollo/Source/Routing/CRRouter.m
@@ -118,6 +118,10 @@ NS_ASSUME_NONNULL_END
 - (void)post:(NSString *)path block:(CRRouteBlock)block {
     [self add:path block:block recursive:NO method:CRHTTPMethodPost];
 }
+  
+- (void)patch:(NSString *)path block:(CRRouteBlock)block {
+    [self add:path block:block recursive:NO method:CRHTTPMethodPatch];
+}
 
 - (void)put:(NSString *)path block:(CRRouteBlock)block {
     [self add:path block:block recursive:NO method:CRHTTPMethodPut];


### PR DESCRIPTION
There were methods on CRRouter for all the HTTP methods except PATCH.

I'm using [this library](https://github.com/depoon/SwiftLocalhost) which depends on Criollo when I discover it. I quick-fixed it using [this method](https://github.com/llinardos/Criollo/blob/888a8383832f57f529b3795117e72c83857dabc5/Criollo/Source/Routing/CRRouter.h#L114) but I think is ok to add the method for the PATCH HTTP method.