### PR TITLE
Add possibility to replace a previosly defined route

### DIFF
--- a/Criollo/Source/Routing/CRRoute.m
+++ b/Criollo/Source/Routing/CRRoute.m
@@ -136,5 +136,19 @@
     }];
     return result;
 }
+    
+- (BOOL)isEqual:(id)object {
+    if ([object isKindOfClass:[CRRoute class]]) {
+        CRRoute *route = (CRRoute *)object;
+        
+        return _method == route.method &&
+            [_path isEqualToString:route.path] &&
+            _recursive == route.recursive ;
+    } else {
+        return false;
+    }
+}
+    
+
 
 @end

--- a/Criollo/Source/Routing/CRRouter.h
+++ b/Criollo/Source/Routing/CRRouter.h
@@ -258,6 +258,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mount:(NSString *)path fileAtPath:(NSString *)filePath options:(CRStaticFileServingOptions)options fileName:(NSString * _Nullable)fileName contentType:(NSString * _Nullable)contentType contentDisposition:(CRStaticFileContentDisposition)contentDisposition;
 
+/**
+ Replaces a block for a pathspec, for all HTTP methods, non-recursively. If there is no block defined for the specified path, the new block will be added.
+ 
+ @param path  The path specification.
+ @param block The `CRRouteBlock` to be executed.
+*/
+- (void)replace:(NSString * _Nullable)path block:(CRRouteBlock)block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Criollo/Source/Routing/CRRouter.m
+++ b/Criollo/Source/Routing/CRRouter.m
@@ -177,6 +177,18 @@ NS_ASSUME_NONNULL_END
     CRRoute* route = [[CRRoute alloc] initWithStaticFileAtPath:filePath options:options fileName:fileName contentType:contentType contentDisposition:contentDisposition path:path];
     [self addRoute:route];
 }
+    
+- (void)replace:(NSString * _Nullable)path block:(CRRouteBlock)block {
+    CRRoute* route = [[CRRoute alloc] initWithBlock:block method:CRHTTPMethodAll path:path recursive:NO];
+    
+    NSUInteger index = [self.routes indexOfObject:route];
+    
+    if (index != NSNotFound) {
+        [self.routes removeObjectAtIndex:index];
+    }
+    
+    [self addRoute:route];
+}
 
 
 #pragma mark - Routing

--- a/CriolloTests/CRRouterTests.m
+++ b/CriolloTests/CRRouterTests.m
@@ -67,5 +67,30 @@ static CRRouteBlock noop;
         XCTAssertTrue([expectedFoo isEqualToString:foo]);
     }
 }
+    
+- (void)testReplacingRoutes {
+    CRRouteBlock block = ^(CRRequest * _Nonnull request, CRResponse * _Nonnull response, CRRouteCompletionBlock  _Nonnull completionHandler){};
+    CRRouter *router = [[CRRouter alloc] init];
+    NSString *testPath = @"/routes/test";
+    CRRoute *route = [[CRRoute alloc] initWithBlock:block method:CRHTTPMethodAll path:testPath recursive:NO];
+    [router addRoute:route];
+    
+    NSArray<CRRouteMatchingResult *> *matches = [router routesForPath:testPath method:CRHTTPMethodGet];
+    
+    XCTAssertNotNil(matches);
+    XCTAssertEqual(1, matches.count);
+    XCTAssertEqual(matches.firstObject.route.block, block);
+    
+    CRRouteBlock newBlock = ^(CRRequest * _Nonnull request, CRResponse * _Nonnull response, CRRouteCompletionBlock  _Nonnull completionHandler){};
+    
+    [router replace:testPath block:newBlock];
+    
+    matches = [router routesForPath:testPath method:CRHTTPMethodGet];
+    
+    XCTAssertNotNil(matches);
+    XCTAssertEqual(1, matches.count);
+    XCTAssertNotEqual(matches.firstObject.route.block, block);
+    XCTAssertEqual(matches.firstObject.route.block, newBlock);
+}
 
 @end


### PR DESCRIPTION
Hi,
I've found replacing a previously defined route functionality useful in my use case. I'd like to use Criollo as mockup service for UI tests of iOS app. I defined default set of responses as JSON files and load them when needed to return a response. When writing a test sometimes I'd like to change response for previously defined route to test some edge cases, i.e. authentication fails 😄 

What do you think about this solution? I know it's not ready to merge yet, because I need to add same feature for rest of HTTP methods, at least 😃 . I just wanted to share this idea with you and maybe get some feedback.

BTW I have an issue when I want to change url to repo in my Podfile. After set it to:
`pod 'Criollo', :git => 'https://github.com/tomekh7/Criollo.git', :branch => 'replacing-routes'`
and invoke `pod install` `Libraries` folder is removed. I'm not able to compile, because lack of `openssl` library. There are also some changes in `config` files, which remove link to `openssl` library. Have you seen such issue?

Cheers,
Tom