### PR TITLE
Fixes #66

### DIFF
--- a/Criollo/Source/CRRequest.h
+++ b/Criollo/Source/CRRequest.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) NSDictionary<NSString *, NSString *> * query;
 @property (nonatomic, readonly, strong, nullable) NSDictionary<NSString *, NSString *> * cookies;
 @property (nonatomic, readonly, strong, nullable) id body;
-@property (nonatomic, readonly, strong, nullable) NSDictionary<NSString *, CRUploadedFile *> * files;
+@property (nonatomic, readonly, strong, nullable) NSDictionary<NSString *, id> * files;
 
 @property (nonatomic, readonly, nullable) CRRequestRange * range;
 

--- a/Criollo/Source/CRRequest.m
+++ b/Criollo/Source/CRRequest.m
@@ -84,7 +84,7 @@
         [queryVars enumerateObjectsUsingBlock:^(NSString*  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) { @autoreleasepool {
             NSArray<NSString *> *queryVarComponents = [[obj stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] componentsSeparatedByString:CRRequestValueSeparator];
             NSString *key = queryVarComponents[0].stringByDecodingURLEncodedString.stringByRemovingPercentEncoding ? : (queryVarComponents[0].stringByDecodingURLEncodedString ? : queryVarComponents[0]);
-            NSString *value = queryVarComponents.count > 1 ? (queryVarComponents[1].stringByDecodingURLEncodedString.stringByRemovingPercentEncoding ? : (queryVarComponents[0].stringByDecodingURLEncodedString ? : queryVarComponents[1])) : @"";
+            NSString *value = queryVarComponents.count > 1 ? (queryVarComponents[1].stringByDecodingURLEncodedString.stringByRemovingPercentEncoding ? : (queryVarComponents[1].stringByDecodingURLEncodedString ? : queryVarComponents[1])) : @"";
             query[key] = value;
         }}];
     }


### PR DESCRIPTION
I'm fairly certain this should work just fine; what it does:
When a new file is being added to the `files` array, it first checks if there's already a `CRUploadedFile` at that key. If so, it turns that key's value into an `NSMutableArray`, containing the original `CRUploadedFile` and new file. At every other point where an individual element of the `files` array is manipulated (as far as I could find), it checks first whether it's a `CRUploadedFile` or an `NSMutableArray`, then acts accordingly.

I tested it on a webpage with a single file upload tag, a multiple file uploads tag, and a combination of both. It seemed to do the job just fine both times.