### PR TITLE
Fixed CRHTTPConnection query URL parsing

### DIFF
--- a/Criollo/Source/HTTP/CRHTTPConnection.m
+++ b/Criollo/Source/HTTP/CRHTTPConnection.m
@@ -151,7 +151,9 @@
                         }
 
                         // TODO: request.URL should be parsed using no memcpy and using the actual scheme
-                        NSURL* URL = [NSURL URLWithString:[NSString stringWithFormat:@"http%@://%@%@", ((CRHTTPServer *)self.server).isSecure ? @"s" : @"", hostSpec, pathSpec]];
+                        NSString* requestString = [NSString stringWithFormat:@"http%@://%@%@", ((CRHTTPServer *)self.server).isSecure ? @"s" : @"", hostSpec, pathSpec];
+                        requestString = [requestString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+                        NSURL* URL = [NSURL URLWithString:requestString];
                         CRRequest* request = [[CRRequest alloc] initWithMethod:CRHTTPMethodMake(methodSpec) URL:URL version:CRHTTPVersionMake(versionSpec) connection:self];
                         [self addRequest:request];
                         self.requestBeingReceived = request;


### PR DESCRIPTION
In CRHTTPConnection.m, the query URL that is being constructed from the HTTP data isn't being percent encoded. This means that if it includes some special characters such as backticks or carets, the `NSURL` that is constructed will be `nil`, and the server won't be able to correctly handle the request.

This PR simply adds percent encoding so that it correctly sets the URL, and services the request as expected.