### PR TITLE
#89: Republish public headers to swift package puublic headers directory

### DIFF
--- a/Criollo/Source/HTTP/CRHTTPConnection.m
+++ b/Criollo/Source/HTTP/CRHTTPConnection.m
@@ -24,11 +24,6 @@
 #import "CRServer_Internal.h"
 #import "NSData+CRLF.h"
 
-typedef NS_ENUM(long, CRHTTPConnectionSocketTag) {
-    CRHTTPConnectionSocketTagBeginReadingRequest = 10,
-    CRHTTPConnectionSocketTagReadingRequestBody = 11,
-};
-
 @interface CRHTTPConnection () {
     NSUInteger requestBodyLength;
     NSUInteger requestBodyReceivedBytesLength;

--- a/Criollo/Source/HTTP/CRHTTPConnection_Internal.h
+++ b/Criollo/Source/HTTP/CRHTTPConnection_Internal.h
@@ -8,6 +8,11 @@
 
 #import "CRHTTPConnection.h"
 
+typedef NS_ENUM(long, CRHTTPConnectionSocketTag) {
+    CRHTTPConnectionSocketTagBeginReadingRequest = 10,
+    CRHTTPConnectionSocketTagReadingRequestBody = 11,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CRHTTPConnection ()

--- a/Criollo/includes/Criollo/CRConnection.h
+++ b/Criollo/includes/Criollo/CRConnection.h
@@ -23,12 +23,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CRConnection : NSObject
 
-@property (nonatomic, weak, nullable) id<CRConnectionDelegate> delegate;
-
 @property (nonatomic, readonly) NSString* remoteAddress;
 @property (nonatomic, readonly) NSUInteger remotePort;
 @property (nonatomic, readonly) NSString* localAddress;
 @property (nonatomic, readonly) NSUInteger localPort;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 @end
 

--- a/Criollo/includes/Criollo/CRResponse.h
+++ b/Criollo/includes/Criollo/CRResponse.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)finish;
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Criollo/includes/Criollo/CRTypes.h
+++ b/Criollo/includes/Criollo/CRTypes.h
@@ -158,3 +158,7 @@ typedef NS_ENUM(NSUInteger, CRStaticFileContentDisposition) {
 };
 
 NS_ASSUME_NONNULL_END
+
+#define CR_OBJC_ABSTRACT {\
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"%s must be implemented in a subclass.", __PRETTY_FUNCTION__] userInfo:nil];\
+}

--- a/CriolloTests/CRHTTPConnectionTests.m
+++ b/CriolloTests/CRHTTPConnectionTests.m
@@ -14,7 +14,7 @@
 
 @class GCDAsyncSocket;
 
-#define CRHTTPConnectionCreate() CRHTTPConnection *connection = [[CRHTTPConnection alloc] init]
+#define CRHTTPConnectionCreate() CRHTTPConnection *connection = [[CRHTTPConnection alloc] initWithSocket:nil server:nil delegate:nil]
 
 #define HTTP11Header ([@"GET /myendpoint HTTP/1.1\r\n\
 Host: criollo.io\r\n\


### PR DESCRIPTION
Republished the headers to SPM public headers directory. This mechanism needs to be changed. #90 has been created for this purpose